### PR TITLE
Modify travis.yml and package.json to allow test suites to run on build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 before_script:
  - "npm run-script setup"
  - "npm run-script build"
- - "npm run-script dev-server"
+ - "npm run-script dev-server-travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
  - "10.6.0 "
 before_script:
  - "npm run-script setup"
- - "npm run-script launch"
- - "npm run dev-server"
+ - "npm run-script build"
+ - "npm run-script dev-server"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
 before_script:
  - "npm run-script setup"
  - "npm run-script launch"
+ - "npm run dev-server"

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack -d -w",
+    "buildOnce": "webpack -d",
     "test": "jest",
     "server": "webpack-dev-server --mode development --open --hot"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "launch": "cd ./client && npm run-script build && cd ../server && node bin/www && cd ../client webpack-dev-server &",
     "build": "cd ./client && npm run-script buildOnce",
     "dev-server": "cd ./server/bin && node www",
+    "dev-server-travis": "cd ./server/bin && node www &",
     "lint:client": "cd ./client && ./node_modules/.bin/eslint \"src/**/*.{js,jsx}\" && echo 'Your code has passed the linting guidelines' || echo 'Please fix the errors listed above'",
     "lint:server": "cd ./server && ../node_modules/.bin/eslint \"routes/**/*.js\" 2>/dev/null && echo 'Your code has passed the linting guidelines' || echo 'Please fix the errors listed above'"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "setup": "npm install && cd ./client && npm install ; cd ../server && npm install",
     "test": "cd ./client && npm test",
     "launch": "cd ./client && npm run-script build && cd ../server && node bin/www && cd ../client webpack-dev-server &",
+    "dev-server": "cd ./server/bin && node www",
     "lint:client": "cd ./client && ./node_modules/.bin/eslint \"src/**/*.{js,jsx}\" && echo 'Your code has passed the linting guidelines' || echo 'Please fix the errors listed above'",
     "lint:server": "cd ./server && ../node_modules/.bin/eslint \"routes/**/*.js\" 2>/dev/null && echo 'Your code has passed the linting guidelines' || echo 'Please fix the errors listed above'"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "setup": "npm install && cd ./client && npm install ; cd ../server && npm install",
     "test": "cd ./client && npm test",
     "launch": "cd ./client && npm run-script build && cd ../server && node bin/www && cd ../client webpack-dev-server &",
+    "build": "cd ./client && npm run-script buildOnce",
     "dev-server": "cd ./server/bin && node www",
     "lint:client": "cd ./client && ./node_modules/.bin/eslint \"src/**/*.{js,jsx}\" && echo 'Your code has passed the linting guidelines' || echo 'Please fix the errors listed above'",
     "lint:server": "cd ./server && ../node_modules/.bin/eslint \"routes/**/*.js\" 2>/dev/null && echo 'Your code has passed the linting guidelines' || echo 'Please fix the errors listed above'"


### PR DESCRIPTION
Issue: .travis.yml before_script ran "npm run launch". As written the launch script would run webpack in development mode and watch the files. This prevented the next steps in launch script to begin. Broke scripts out to build the package ONCE (no continuous monitoring needed in a travis build), and start the server then detach.

Testing suite is now functional in Travis builds.