### PR TITLE
Fix bug assigning end time to events

### DIFF
--- a/client/src/components/CardMaker.js
+++ b/client/src/components/CardMaker.js
@@ -48,11 +48,11 @@ export default function CardMaker({ event }) {
   }
 
   function addToCalendar(event) {
-    console.log('Clicked on:', event)
+    // console.log('Clicked on:', event)
     let eventStart = new Date(event.time_start);
     let eventEnd;
     if (event.time_end) {
-      eventEnd = new Date(event_time.start);
+      eventEnd = new Date(event.time_end);
     } else {
       eventEnd = new Date(eventStart)
       eventEnd.setHours(eventEnd.getHours() + 2);
@@ -66,13 +66,13 @@ export default function CardMaker({ event }) {
         dateTime: eventEnd
       }
     };
-    console.log(gCalEvent)
+    // console.log(gCalEvent)
     let request = window.gapi.client.calendar.events.insert({
       calendarId: 'primary',
       resource: gCalEvent
     });
     request.execute(function (event) {
-      console.log(event.htmlLink);
+      // console.log(event.htmlLink);
     });
 
   }


### PR DESCRIPTION
![cal end time bug](https://user-images.githubusercontent.com/48231066/62969283-88f43b80-bdd2-11e9-95bf-2f28a9091d99.png)

Fixed line 55 to read:
      eventEnd = new Date(event.time_end);
